### PR TITLE
Removed /public directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ Homestead.yaml
 Homestead.json
 .env
 .idea
-/public


### PR DESCRIPTION
Make is difficult when one has to `git push` the project, as it ignores the whole `/public` directory. Even if the development logo and other images or custom CSS or JS files are there.